### PR TITLE
build: Bundle tinyxml on all platforms, not just win32 (#8)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,13 +185,11 @@ set(LIBHDRS
 	)
 
 		
-IF(WIN32)
 SET(SRC_TINYXML
             src/tinyxml/tinyxml.cpp
             src/tinyxml/tinyxmlparser.cpp
             src/tinyxml/tinyxmlerror.cpp
 )
-ENDIF(WIN32)
 
 set(EXTINCLUDE extinclude/nlohmann/json.hpp extinclude/ODAPI.h)
 


### PR DESCRIPTION
Bundling the library on all platforms avoids broken linkage on
flatpak and most likely also macos.

Closes: #8