### PR TITLE
Use correct way to get writable data dir (#7, OpenCPN#2312)

### DIFF
--- a/src/celestial_navigation_pi.cpp
+++ b/src/celestial_navigation_pi.cpp
@@ -256,19 +256,11 @@ bool celestial_navigation_pi::RenderOverlayAll(wxDC *dc, PlugIn_ViewPort *vp)
 
 wxString celestial_navigation_pi::StandardPath()
 {
-    wxStandardPathsBase& std_path = wxStandardPathsBase::Get();
-    wxString s = wxFileName::GetPathSeparator();
-#if defined(__WXMSW__)
-    wxString stdPath  = std_path.GetConfigDir();
-#elif defined(__WXGTK__) || defined(__WXQT__)
-    wxString stdPath  = std_path.GetUserDataDir();
-#elif defined(__WXOSX__)
-    wxString stdPath  = (std_path.GetUserConfigDir() + s + _T("opencpn"));   // should be ~/Library/Preferences/opencpn
-#endif
-
-    return stdPath + wxFileName::GetPathSeparator() +
-        _T("plugins") + wxFileName::GetPathSeparator() +
-        _T("celestial_navigation") +  wxFileName::GetPathSeparator();
+    wxString stdPath(*GetpPrivateApplicationDataLocation());
+    stdPath = stdPath + wxFileName::GetPathSeparator() + "plugins"
+        + wxFileName::GetPathSeparator() + "celestial_navigation"
+        + wxFileName::GetPathSeparator();
+    return stdPath;
 }
 
 static double s_boat_lat, s_boat_lon;


### PR DESCRIPTION
Use GetpPrivateApplicationDataLocation() to get the private, writable data directory. This fixes current code which doesn't handle flatpak (and also might run into troubles with upcoming, new platforms).

Doing so, be careful to not update the core OpenCPN data, see https://github.com/OpenCPN/OpenCPN/issues/2312

Closes: #7

Tested on flatpak only.