### PR TITLE
Fix build and reference dataset

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -80,6 +80,7 @@ target_link_libraries(celestial_tests
         ${wxWidgets_LIBRARIES}
         ocpn::api
         ocpn::tinyxml
+        ${OPENGL_LIBRARIES}
 )
 
 # Set optimization level for debug builds

--- a/test/altitude_tests.cpp
+++ b/test/altitude_tests.cpp
@@ -74,8 +74,8 @@ TEST_F(AltitudeTest, SunLowerLimbExample) {
   sight.Recompute(0);  // 0 = no clock offset
 
   // Expected values from Nautical Almanac (NA)
-  const double ALMANAC_MAIN_CORRECTION = DegMin2DecDeg(0, 11.6);  // 11.6'
-  const double ALMANAC_HO = DegMin2DecDeg(11, 30.6);    // Ho: 11°30.6'
+  const double ALMANAC_MAIN_CORRECTION = DegMin2DecDeg(0, 5.8);  // 5.8'
+  const double ALMANAC_HO = DegMin2DecDeg(11, 30.8);    // Ho: 11°30.8'
   const double ALMANAC_GHA = DegMin2DecDeg(128, 20.5);  // GHA: 128°20.5'
   const double ALMANAC_DEC = -DegMin2DecDeg(18, 15.2);  // Dec: S18°15.2'
 
@@ -110,6 +110,7 @@ TEST_F(AltitudeTest, SunLowerLimbExample) {
   // 3. Test Body Position (GHA, Dec)
   double gha, dec;
   sight.BodyLocation(datetime, &dec, &gha, nullptr, nullptr);
+  gha = resolve_heading_positive(-gha);
 
   std::cout << "\nBody Position Analysis:" << std::endl;
   std::cout << "  Almanac GHA: " << DecDegToDegMin(ALMANAC_GHA)

--- a/test/mock_plugin_api.cpp
+++ b/test/mock_plugin_api.cpp
@@ -113,6 +113,8 @@ DECL_EXP void JumpToPosition(double lat, double lon, double scale) {}
 
 wxString* GetpPrivateApplicationDataLocation(void) { return nullptr; }
 
+wxString *GetpSharedDataLocation(void) { return nullptr; }
+
 class ObservableListener {
 public:
   ObservableListener(int /* unused */, wxEvtHandler* handler, wxEventType type)


### PR DESCRIPTION
The reference dataset comes from a PDF file written by Bob Bossert and can be found here:
https://github.com/rgleason/celestial_navigation_pi/issues/24

In the PDF file, it is said (for Nautical Almanac based calculation) that Hs is 11°25.0', and Ho 11°30.6'. This gives a correction of 5.6', not 11.6' at it is wrongly stated.

Later, the author states that his Main Correction does not account for Sun Parallax, which accounts for most of the difference between Nautical Almanac and OpenCPN, equal to 0.2'.

So the Main Correction is in fact 5.8'.

Regarding the reference Ho, the extra 0.2' should be accounted for in the test.

Finally GHA was not reduced to the [0..360) interval, giving a false negative into the test code.