### PR TITLE
Fix incorrect altitude in the "Find Body" dialog

### DIFF
--- a/src/FindBodyDialog.cpp
+++ b/src/FindBodyDialog.cpp
@@ -94,25 +94,22 @@ void FindBodyDialog::OnDone( wxCommandEvent& event )
 void FindBodyDialog::Update()
 {
     /* NOTE: we do not peform any altitude corrections here */
-    double lat1, lon1, lat2, lon2, bearing, dist;
+    double lat1, lon1, lat2, lon2, hc, zn;
     m_tLatitude->GetValue().ToDouble(&lat1);
     m_tLongitude->GetValue().ToDouble(&lon1);
-    
+
     m_Sight.BodyLocation(m_Sight.m_DateTime, &lat2, &lon2, 0, 0);
-
-    ll_gc_ll_reverse(lat1, lon1, lat2, lon2, &bearing, &dist);
-
-    dist = 90 - dist/60;
+    m_Sight.AltitudeAzimuth(lat1, lon1, lat2, lon2, &hc, &zn);
 
     if(m_cbMagneticAzimuth->GetValue()) {
         double results[14];
-          
+
         geomag_calc(lat1, lon1, m_Sight.m_EyeHeight,
                     m_Sight.m_DateTime.GetDay(), m_Sight.m_DateTime.GetMonth(),
                     m_Sight.m_DateTime.GetYear(), results);
-        bearing -= results[0];
+        zn -= results[0];
     }
-    
-    m_tAltitude->SetValue(wxString::Format(_T("%f"), dist));
-    m_tAzimuth->SetValue(wxString::Format(_T("%f"), bearing));
+
+    m_tAltitude->SetValue(wxString::Format(_T("%f"), hc));
+    m_tAzimuth->SetValue(wxString::Format(_T("%f"), zn));
 }

--- a/src/Sight.cpp
+++ b/src/Sight.cpp
@@ -965,6 +965,35 @@ wxRealPoint Sight::DistancePoint( double altitude, double trace, double lat, dou
     return wxRealPoint(rlat, rlon);
  }
 
+/* Calculate Hc and Zn from from one position to another */
+void Sight::AltitudeAzimuth(double lat1, double lon1, double lat2, double lon2,
+                            double *hc, double *zn)
+{
+	double lat1_r = d_to_r(lat1);
+	double lon1_r = d_to_r(lon1);
+	double lat2_r = d_to_r(lat2);
+	double lon2_r = d_to_r(lon2);
+
+	double lha = lon1 - lon2;
+	lha = resolve_heading_positive(lha);
+	double lha_r = d_to_r(lha);
+
+	double hc_r = asin( sin(lat1_r)*sin(lat2_r) + cos(lat1_r) * cos(lat2_r) * cos(lha_r) );
+	double zn_r = acos( (sin(lat2_r) - sin(lat1_r) * sin(hc_r)) / (cos(lat1_r) * cos(hc_r)) );
+
+	*hc = r_to_d(hc_r);
+	*zn = r_to_d(zn_r);
+	if (lat1 > 0) {
+		if (lha < 180)
+			*zn = 360 - *zn;
+	} else {
+		if (lha > 180)
+			*zn = 180 - *zn;
+		else
+			*zn = 180 + *zn;
+	}
+}
+
 void Sight::BuildAltitudeLineOfPosition(double tracestep,
                                         double altitudemin, double altitudemax, double altitudestep,
                                         double timemin, double timemax, double timestep)

--- a/src/Sight.h
+++ b/src/Sight.h
@@ -102,6 +102,8 @@ public:
     virtual void Render(wxDC *dc, PlugIn_ViewPort &pVP);
 
     void BodyLocation(wxDateTime time, double *lat, double *lon, double *ghaash, double *rad);
+    void AltitudeAzimuth(double lat1, double lon1, double lat2, double lon2,
+                         double *hc, double *zn);
     std::list<wxRealPoint> GetPoints();
 
     wxString m_CalcStr;


### PR DESCRIPTION
The altitude (Hc) is now consistent with the plotted LOP: one can measure the distance between the starting point of "Find Body" and the LOP, and should find the same value as the result of Hc - Ho (taken from "Calculation" tab.