### PR TITLE
Force drawing of LOP at any resolution.

### DIFF
--- a/src/Sight.h
+++ b/src/Sight.h
@@ -125,6 +125,7 @@ protected:
     wxRealPointList *ReduceToConvexPolygon(wxRealPointList *points);
 
     std::list<wxRealPointList*> polygons;
+    wxRealPointList lines;
 
 private:
     wxRealPoint DistancePoint( double altitude, double trace, double lat, double lon);
@@ -137,7 +138,7 @@ private:
                                     double azimuthmin, double azimuthmax, double azimuthstep,
                                     double timemin, double timemax, double timestep);
 
-    void DrawPolygon(PlugIn_ViewPort &VP, wxRealPointList &area);
+    void DrawPolygon(PlugIn_ViewPort &VP, wxRealPointList &area, bool poly);
 
     wxDC *m_dc;
 

--- a/src/SightDialog.cpp
+++ b/src/SightDialog.cpp
@@ -177,14 +177,6 @@ SightDialog::SightDialog( wxWindow* parent, Sight &s, int clock_offset)
 
 SightDialog::~SightDialog( )
 {
-   if(m_Sight.m_MeasurementCertainty < .6) {
-       wxMessageDialog w
-           ( m_parent,
-             _("Measurement certainty likely set to small, sight may not appear "),
-             _("Warning"), wxOK | wxICON_WARNING );
-       w.ShowModal();
-   }
-
     wxFileConfig *pConf = GetOCPNConfigObject();
     pConf->SetPath( _T("/PlugIns/CelestialNavigation") );
 


### PR DESCRIPTION
This commit forces the drawing of LOPs with a 3 pixels wide line, at any resolution. Zooming in will reveal the real width (depending on the minutes of certainty).

The dialog warning that the sights might not show when certainty measurement is too small has been removed.