### PR TITLE
Add offline planning, running fixes, almanac and eclipse support

### DIFF
--- a/eclipse/src/data_pack.cpp
+++ b/eclipse/src/data_pack.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 namespace eclipse {
 namespace {
@@ -137,12 +138,16 @@ DataPackStatus ReadDigest(const std::string& path, const std::string& label) {
     return status;
   }
   Sha256 digest;
-  unsigned char buffer[1024 * 1024];
+  // Windows 32-bit UI threads commonly have a 1 MiB stack.  Keeping this
+  // 1 MiB read buffer on the stack exhausted it when the eclipse dialog
+  // verified DE440s.  The buffer is working storage, so keep it on the heap.
+  std::vector<unsigned char> buffer(1024 * 1024);
   while (input) {
-    input.read(reinterpret_cast<char*>(buffer), sizeof(buffer));
+    input.read(reinterpret_cast<char*>(buffer.data()),
+               static_cast<std::streamsize>(buffer.size()));
     const std::streamsize count = input.gcount();
     if (count > 0) {
-      digest.Update(buffer, static_cast<std::size_t>(count));
+      digest.Update(buffer.data(), static_cast<std::size_t>(count));
       status.bytes += static_cast<std::uint64_t>(count);
     }
   }

--- a/src/celestial_navigation_pi.cpp
+++ b/src/celestial_navigation_pi.cpp
@@ -167,9 +167,15 @@ bool celestial_navigation_pi::DeInit(void) {
   RemovePlugInTool(m_leftclick_tool_id);
 
   if (m_pCelestialNavigationDialog) {
-    m_pCelestialNavigationDialog->Close();
-    delete m_pCelestialNavigationDialog;
+    // Do not route application shutdown through the normal window-close
+    // handler.  OnDialogClose() uses wxWindow::Destroy(), which is deferred;
+    // once OpenCPN's main event loop is stopping that deferred destruction can
+    // leave this top-level dialog alive and keep the process running.  Clear
+    // the plugin pointer first and destroy the owned dialog synchronously.
+    CelestialNavigationDialog* dialog = m_pCelestialNavigationDialog;
     m_pCelestialNavigationDialog = NULL;
+    dialog->Hide();
+    delete dialog;
   }
   return true;
 }
@@ -429,9 +435,11 @@ void celestial_navigation_pi::SetPluginMessage(wxString& message_id,
 }
 
 void celestial_navigation_pi::OnDialogClose() {
-  m_pCelestialNavigationDialog->Hide();
-  m_pCelestialNavigationDialog->Destroy();
+  CelestialNavigationDialog* dialog = m_pCelestialNavigationDialog;
   m_pCelestialNavigationDialog = NULL;
+  if (!dialog) return;
+  dialog->Hide();
+  dialog->Destroy();
 }
 
 double celestial_navigation_pi_GetWMM(double lat, double lon, double altitude,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,7 +118,6 @@ target_link_libraries(celestial_tests
         ocpn::wxjson
         ocpn::plugin-dc
         celestial::eclipse_core
-        ${OPENGL_LIBRARIES}
 )
 
 # Set optimization level for debug builds


### PR DESCRIPTION
Copied from POB PR #255 

## Summary

This draft brings the complete v2.7 contribution onto a branch based directly
on the maintained `rgleason/celestial_navigation_pi` repository. It is intended
for build/testing and to agree the best integration shape.

The contribution adds:

- time-integrity reporting for local, UTC, GNSS/NMEA and chrony sources;
- observed sunrise/sunset horizon events with bearing corrections and
  uncertainty estimates;
- an offline Sun, Moon and sight planner, including rise/set/twilight tables,
  sky plots, sight ranking and CSV export;
- numerical running fixes, sequence analysis, noon and Polaris helpers;
- rebuilt lunar-distance and coastal-sextant workflows;
- an offline route/position-aware voyage almanac and printable PDF workflows;
- instrument calibration and related workflow improvements; and
- an offline solar-eclipse planner using JPL DE440, with optional DE440 lunar
  orientation and NASA LOLA lunar-limb refinement.

## Review shape

This is deliberately opened as a draft umbrella PR so the full feature set can
be built and exercised together. The proposed end result is for this complete
enhanced version to become the next maintained Celestial Navigation plugin
release, rather than for only isolated features to be cherry-picked. I am very
happy to split the work into smaller, ordered PRs if that is easier to review
and merge, with those stages leading to the same complete update.

## Eclipse data distribution

No large binary data or Git LFS objects are included in this PR. Whole-file,
versioned copies of all three data packs are published in the GitHub release:

https://github.com/pob220/celestial_navigation_pi/releases/tag/eclipse-data-2026.1

The release contains `de440s.bsp`, `moon_pa_de440_200625.bpc`,
`lola64-pa.bin`, `SHA256SUMS`, individual provenance manifests and an offline
use guide. Each CI download is atomic and accepted only after its exact
SHA-256 matches the source-tree manifest. The dedicated Debian 12 data job
downloads all three assets and exercises the optional lunar-orientation and
LOLA tests as well as the required DE440 tests.

Users import downloaded files through the Eclipse dialog; runtime calculation
performs no network access. Ordinary navigation, planning and almanac features
do not require these packs. Lunar-distance calculations use DE440 when
installed and otherwise retain the bundled analytical fallback.

## Validation

The plugin and its tests build successfully with:

```sh
cmake -S . -B build -DOCPN_BUILD_TEST=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel 4
ctest --test-dir build --output-on-failure
```

With the checksum-verified `de440s.bsp` staged at the test path, all 82 plugin
tests across 27 suites pass.

The independent eclipse engine also builds and passes its core suite:

```sh
cmake -S eclipse -B build-eclipse -DCMAKE_BUILD_TYPE=Release
cmake --build build-eclipse --parallel 4
ctest --test-dir build-eclipse --output-on-failure
```

The optional-data run of `eclipse_core_tests`, using all three GitHub-hosted
packs, also passes without skipped optional-data tests.

## CI and release hand-off

CircleCI builds the same 19 platform identities as the current official
Celestial Navigation catalogue entry. For the reviewed PR build, every target
completed successfully. Each retained archive and XML matched its generated
`SHA256SUMS`; all archives contained the plugin binary, bundled analytical
ephemeris and HTML manual; and all metadata files validated against the
current `OpenCPN/plugins` schema with 19 unique target identities.

The reviewed-alpha workflow is opt-in, performs a fresh full-matrix build,
retains the evidence, and stops at a manual approval gate before Cloudsmith
credentials are made available. A no-upload rehearsal successfully staged all
19 package/metadata pairs.

The maintainer checklist in
[`docs/ci-release.md`](https://github.com/pob220/celestial_navigation_pi-contrib/blob/full-improvements/docs/ci-release.md)
documents the exact official Cloudsmith Alpha target, CircleCI gate, metadata
download/validation commands and subsequent `OpenCPN/plugins` Alpha catalogue
PR. Cloudsmith publication and catalogue inclusion remain separate reviewable
actions.
