### PR TITLE
Fix Windows background-task crash (2.8.4.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(LONG_DESCRIPTION
 set(VERSION_MAJOR "2")
 set(VERSION_MINOR "8")
 set(VERSION_PATCH "4")
-set(VERSION_TWEAK "0")
+set(VERSION_TWEAK "1")
 set(VERSION_DATE  "07/09/2026" )# DD/MM/YYYY format
 set(OCPN_MIN_VERSION "improve")
 
@@ -196,12 +196,14 @@ SET(SRCS
         src/HtmlHelp.cpp
         src/EclipseDialog.cpp
         src/EclipseDataFiles.cpp
+        src/EclipseVerificationWorker.cpp
         src/TimeStatus.cpp
         src/CelestialNavigationUI.cpp
         src/SightDialog.cpp
         src/Sight.cpp
         src/LunarDistanceEngine.cpp
         src/LunarSessionEngine.cpp
+        src/LunarSessionWorker.cpp
         src/SextantCalibrationEngine.cpp
         src/LunarToolsDialog.cpp
         src/AlmanacGenerator.cpp
@@ -238,6 +240,7 @@ SET(HDRS
         src/HtmlHelp.h
         src/EclipseDialog.h
         src/EclipseDataFiles.h
+        src/EclipseVerificationWorker.h
         src/TimeStatus.h
         src/CelestialNavigationUI.h
         src/ClockCorrectionDialog.h
@@ -248,6 +251,7 @@ SET(HDRS
         src/Sight.h
         src/LunarDistanceEngine.h
         src/LunarSessionEngine.h
+        src/LunarSessionWorker.h
         src/SextantCalibrationEngine.h
         src/LunarToolsDialog.h
         src/AlmanacGenerator.h

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -22,12 +22,14 @@ src/HorizonEventDialog.cpp
 src/HtmlHelp.cpp
 src/EclipseDialog.cpp
 src/EclipseDataFiles.cpp
+src/EclipseVerificationWorker.cpp
 src/TimeStatus.cpp
 src/CelestialNavigationUI.cpp
 src/SightDialog.cpp
 src/Sight.cpp
 src/LunarDistanceEngine.cpp
 src/LunarSessionEngine.cpp
+src/LunarSessionWorker.cpp
 src/SextantCalibrationEngine.cpp
 src/LunarToolsDialog.cpp
 src/AlmanacGenerator.cpp
@@ -61,6 +63,7 @@ src/HorizonEventDialog.h
 src/HtmlHelp.h
 src/EclipseDialog.h
 src/EclipseDataFiles.h
+src/EclipseVerificationWorker.h
 src/TimeStatus.h
 src/CelestialNavigationUI.h
 src/ClockCorrectionDialog.h
@@ -71,6 +74,7 @@ src/icons.h
 src/Sight.h
 src/LunarDistanceEngine.h
 src/LunarSessionEngine.h
+src/LunarSessionWorker.h
 src/SextantCalibrationEngine.h
 src/LunarToolsDialog.h
 src/AlmanacGenerator.h

--- a/po/POTFILES.in.test
+++ b/po/POTFILES.in.test
@@ -22,12 +22,14 @@ src/HorizonEventDialog.cpp
 src/HtmlHelp.cpp
 src/EclipseDialog.cpp
 src/EclipseDataFiles.cpp
+src/EclipseVerificationWorker.cpp
 src/TimeStatus.cpp
 src/CelestialNavigationUI.cpp
 src/SightDialog.cpp
 src/Sight.cpp
 src/LunarDistanceEngine.cpp
 src/LunarSessionEngine.cpp
+src/LunarSessionWorker.cpp
 src/SextantCalibrationEngine.cpp
 src/LunarToolsDialog.cpp
 src/AlmanacGenerator.cpp
@@ -61,6 +63,7 @@ src/HorizonEventDialog.h
 src/HtmlHelp.h
 src/EclipseDialog.h
 src/EclipseDataFiles.h
+src/EclipseVerificationWorker.h
 src/TimeStatus.h
 src/CelestialNavigationUI.h
 src/ClockCorrectionDialog.h
@@ -71,6 +74,7 @@ src/icons.h
 src/Sight.h
 src/LunarDistanceEngine.h
 src/LunarSessionEngine.h
+src/LunarSessionWorker.h
 src/SextantCalibrationEngine.h
 src/LunarToolsDialog.h
 src/AlmanacGenerator.h

--- a/src/EclipseDialog.cpp
+++ b/src/EclipseDialog.cpp
@@ -25,9 +25,7 @@
 #include <wx/utils.h>
 
 #include <algorithm>
-#include <chrono>
 #include <cmath>
-#include <future>
 #include <iomanip>
 #include <sstream>
 
@@ -226,7 +224,7 @@ EclipseDialog::~EclipseDialog() {
     OCPN_cancelDownloadFileBackground(m_download_handle);
     m_download_handle = 0;
   }
-  if (m_verification_future.valid()) m_verification_future.wait();
+  m_verification_worker.Wait();
   if (!m_download_temp.empty() && wxFileExists(m_download_temp))
     wxRemoveFile(m_download_temp);
 }
@@ -694,23 +692,21 @@ void EclipseDialog::BeginVerification(EclipseDataKind kind,
       wxString::FromUTF8(
           celestial_navigation::GetEclipseDataFileSpec(kind).display_name)
           .c_str()));
-  m_verification_future = std::async(std::launch::async, [kind, native_path]() {
-    const eclipse::DataPackStatus status =
-        celestial_navigation::VerifyEclipseDataFile(kind, native_path);
-    VerificationResult result;
-    result.valid = status.valid;
-    result.error = status.error;
-    return result;
-  });
+  wxString worker_error;
+  if (!m_verification_worker.Start(kind, native_path, &worker_error)) {
+    m_verifying = false;
+    m_verification_purpose = VERIFY_NONE;
+    if (purpose == VERIFY_DOWNLOAD && wxFileExists(path)) wxRemoveFile(path);
+    FinishInstallation(false, worker_error);
+    return;
+  }
   m_verification_timer.Start(100);
 }
 
 void EclipseDialog::OnVerificationTimer(wxTimerEvent&) {
-  if (!m_verifying || !m_verification_future.valid()) return;
-  if (m_verification_future.wait_for(std::chrono::milliseconds(0)) !=
-      std::future_status::ready)
-    return;
-  const VerificationResult result = m_verification_future.get();
+  if (!m_verifying) return;
+  celestial_navigation::EclipseVerificationWorker::Result result;
+  if (!m_verification_worker.TryTakeResult(&result)) return;
   m_verification_timer.Stop();
   m_verifying = false;
   if (m_verification_purpose == VERIFY_INSTALLED) {

--- a/src/EclipseDialog.h
+++ b/src/EclipseDialog.h
@@ -1,7 +1,6 @@
 #ifndef CELESTIAL_NAVIGATION_ECLIPSE_DIALOG_H
 #define CELESTIAL_NAVIGATION_ECLIPSE_DIALOG_H
 
-#include <future>
 #include <string>
 #include <vector>
 
@@ -9,6 +8,7 @@
 #include <wx/timer.h>
 
 #include "EclipseDataFiles.h"
+#include "EclipseVerificationWorker.h"
 #include "eclipse/engine.h"
 
 class piDC;
@@ -71,11 +71,6 @@ private:
   wxString DataPath(celestial_navigation::EclipseDataKind kind) const;
   bool DataVerified(celestial_navigation::EclipseDataKind kind) const;
 
-  struct VerificationResult {
-    bool valid;
-    std::string error;
-  };
-
   celestial_navigation_pi* m_plugin;
   eclipse::EclipseEngine m_engine;
   bool m_engine_ready;
@@ -111,7 +106,7 @@ private:
   bool m_cancel_requested;
 
   wxTimer m_verification_timer;
-  std::future<VerificationResult> m_verification_future;
+  celestial_navigation::EclipseVerificationWorker m_verification_worker;
   bool m_verifying;
   int m_verification_purpose;
   celestial_navigation::EclipseDataKind m_verification_kind;

--- a/src/EclipseVerificationWorker.cpp
+++ b/src/EclipseVerificationWorker.cpp
@@ -1,0 +1,117 @@
+#include "EclipseVerificationWorker.h"
+
+#include <exception>
+#include <new>
+
+namespace celestial_navigation {
+
+class EclipseVerificationWorker::WorkerThread : public wxThread {
+public:
+  WorkerThread(EclipseVerificationWorker* owner, EclipseDataKind kind,
+               const std::string& path, const VerifyFunction& verify)
+      : wxThread(wxTHREAD_JOINABLE),
+        m_owner(owner),
+        m_kind(kind),
+        m_path(path),
+        m_verify(verify) {}
+
+private:
+  ExitCode Entry() override {
+    Result result;
+    try {
+      result = m_verify(m_kind, m_path);
+    } catch (const std::exception& e) {
+      result.valid = false;
+      result.error = std::string("Verification failed: ") + e.what();
+    } catch (...) {
+      result.valid = false;
+      result.error = "Verification failed with an unexpected error.";
+    }
+    m_owner->Publish(result);
+    return static_cast<ExitCode>(0);
+  }
+
+  EclipseVerificationWorker* m_owner;
+  EclipseDataKind m_kind;
+  std::string m_path;
+  VerifyFunction m_verify;
+};
+
+EclipseVerificationWorker::EclipseVerificationWorker(
+    const VerifyFunction& verify)
+    : m_verify(verify), m_result_ready(false), m_thread(NULL) {
+  if (!m_verify) m_verify = VerifyFile;
+}
+
+EclipseVerificationWorker::~EclipseVerificationWorker() { Wait(); }
+
+bool EclipseVerificationWorker::Start(EclipseDataKind kind,
+                                      const std::string& path,
+                                      wxString* error) {
+  if (m_thread) {
+    if (error) *error = "A verification task is already running.";
+    return false;
+  }
+  {
+    wxCriticalSectionLocker lock(m_result_lock);
+    m_result = Result();
+    m_result_ready = false;
+  }
+
+  WorkerThread* thread =
+      new (std::nothrow) WorkerThread(this, kind, path, m_verify);
+  if (!thread) {
+    if (error) *error = "Unable to allocate the verification worker.";
+    return false;
+  }
+  if (thread->Create() != wxTHREAD_NO_ERROR) {
+    delete thread;
+    if (error) *error = "Unable to create the verification worker.";
+    return false;
+  }
+  m_thread = thread;
+  if (thread->Run() != wxTHREAD_NO_ERROR) {
+    m_thread = NULL;
+    delete thread;
+    if (error) *error = "Unable to start the verification worker.";
+    return false;
+  }
+  return true;
+}
+
+bool EclipseVerificationWorker::TryTakeResult(Result* result) {
+  if (!result || !m_thread) return false;
+  {
+    wxCriticalSectionLocker lock(m_result_lock);
+    if (!m_result_ready) return false;
+    *result = m_result;
+    m_result_ready = false;
+  }
+  Wait();
+  return true;
+}
+
+void EclipseVerificationWorker::Wait() {
+  WorkerThread* thread = m_thread;
+  if (!thread) return;
+  thread->Wait();
+  delete thread;
+  m_thread = NULL;
+}
+
+void EclipseVerificationWorker::Publish(const Result& result) {
+  wxCriticalSectionLocker lock(m_result_lock);
+  m_result = result;
+  m_result_ready = true;
+}
+
+EclipseVerificationWorker::Result EclipseVerificationWorker::VerifyFile(
+    EclipseDataKind kind, const std::string& path) {
+  const eclipse::DataPackStatus status = VerifyEclipseDataFile(kind, path);
+  Result result;
+  result.valid = status.valid;
+  result.error = status.error;
+  return result;
+}
+
+}  // namespace celestial_navigation

--- a/src/EclipseVerificationWorker.h
+++ b/src/EclipseVerificationWorker.h
@@ -1,0 +1,56 @@
+#ifndef CELESTIAL_NAVIGATION_ECLIPSE_VERIFICATION_WORKER_H
+#define CELESTIAL_NAVIGATION_ECLIPSE_VERIFICATION_WORKER_H
+
+#include <functional>
+#include <string>
+
+#include <wx/string.h>
+#include <wx/thread.h>
+
+#include "EclipseDataFiles.h"
+
+namespace celestial_navigation {
+
+// Runs potentially expensive astronomy-data verification using wx's native
+// threading ABI.  In particular, this deliberately avoids std::async: a
+// recent MSVC-built plug-in can be loaded by OpenCPN alongside an older
+// bundled msvcp140.dll, where the STL/PPL async task bridge is not safe.
+class EclipseVerificationWorker {
+public:
+  struct Result {
+    Result() : valid(false) {}
+    bool valid;
+    std::string error;
+  };
+
+  typedef std::function<Result(EclipseDataKind, const std::string&)>
+      VerifyFunction;
+
+  explicit EclipseVerificationWorker(
+      const VerifyFunction& verify = VerifyFunction());
+  ~EclipseVerificationWorker();
+
+  EclipseVerificationWorker(const EclipseVerificationWorker&) = delete;
+  EclipseVerificationWorker& operator=(const EclipseVerificationWorker&) =
+      delete;
+
+  bool Start(EclipseDataKind kind, const std::string& path, wxString* error);
+  bool TryTakeResult(Result* result);
+  void Wait();
+
+private:
+  class WorkerThread;
+
+  void Publish(const Result& result);
+  static Result VerifyFile(EclipseDataKind kind, const std::string& path);
+
+  VerifyFunction m_verify;
+  mutable wxCriticalSection m_result_lock;
+  Result m_result;
+  bool m_result_ready;
+  WorkerThread* m_thread;
+};
+
+}  // namespace celestial_navigation
+
+#endif

--- a/src/LunarSessionWorker.cpp
+++ b/src/LunarSessionWorker.cpp
@@ -1,0 +1,117 @@
+#include "LunarSessionWorker.h"
+
+#include <exception>
+#include <new>
+
+namespace celestial_navigation {
+
+class LunarSessionWorker::WorkerThread : public wxThread {
+public:
+  WorkerThread(LunarSessionWorker* owner,
+               const std::vector<lunar_session::SessionObservation>& entries,
+               const lunar_session::Options& options,
+               const SolveFunction& solve)
+      : wxThread(wxTHREAD_JOINABLE),
+        m_owner(owner),
+        m_entries(entries),
+        m_options(options),
+        m_solve(solve) {}
+
+private:
+  ExitCode Entry() override {
+    lunar_session::Result result;
+    try {
+      result = m_solve(m_entries, m_options);
+    } catch (const std::exception& e) {
+      result.valid = false;
+      result.error =
+          std::string("Lunar-session calculation failed: ") + e.what();
+    } catch (...) {
+      result.valid = false;
+      result.error =
+          "Lunar-session calculation failed with an unexpected error.";
+    }
+    m_owner->Publish(result);
+    return static_cast<ExitCode>(0);
+  }
+
+  LunarSessionWorker* m_owner;
+  std::vector<lunar_session::SessionObservation> m_entries;
+  lunar_session::Options m_options;
+  SolveFunction m_solve;
+};
+
+LunarSessionWorker::LunarSessionWorker(const SolveFunction& solve)
+    : m_solve(solve), m_result_ready(false), m_thread(NULL) {
+  if (!m_solve) m_solve = Solve;
+}
+
+LunarSessionWorker::~LunarSessionWorker() { Wait(); }
+
+bool LunarSessionWorker::Start(
+    const std::vector<lunar_session::SessionObservation>& entries,
+    const lunar_session::Options& options, wxString* error) {
+  if (m_thread) {
+    if (error) *error = "A lunar-session calculation is already running.";
+    return false;
+  }
+  {
+    wxCriticalSectionLocker lock(m_result_lock);
+    m_result = lunar_session::Result();
+    m_result_ready = false;
+  }
+
+  WorkerThread* thread =
+      new (std::nothrow) WorkerThread(this, entries, options, m_solve);
+  if (!thread) {
+    if (error) *error = "Unable to allocate the lunar-session worker.";
+    return false;
+  }
+  if (thread->Create() != wxTHREAD_NO_ERROR) {
+    delete thread;
+    if (error) *error = "Unable to create the lunar-session worker.";
+    return false;
+  }
+  m_thread = thread;
+  if (thread->Run() != wxTHREAD_NO_ERROR) {
+    m_thread = NULL;
+    delete thread;
+    if (error) *error = "Unable to start the lunar-session worker.";
+    return false;
+  }
+  return true;
+}
+
+bool LunarSessionWorker::TryTakeResult(lunar_session::Result* result) {
+  if (!result || !m_thread) return false;
+  {
+    wxCriticalSectionLocker lock(m_result_lock);
+    if (!m_result_ready) return false;
+    *result = m_result;
+    m_result_ready = false;
+  }
+  Wait();
+  return true;
+}
+
+void LunarSessionWorker::Wait() {
+  WorkerThread* thread = m_thread;
+  if (!thread) return;
+  thread->Wait();
+  delete thread;
+  m_thread = NULL;
+}
+
+void LunarSessionWorker::Publish(const lunar_session::Result& result) {
+  wxCriticalSectionLocker lock(m_result_lock);
+  m_result = result;
+  m_result_ready = true;
+}
+
+lunar_session::Result LunarSessionWorker::Solve(
+    const std::vector<lunar_session::SessionObservation>& entries,
+    const lunar_session::Options& options) {
+  return lunar_session::Solve(entries, options);
+}
+
+}  // namespace celestial_navigation

--- a/src/LunarSessionWorker.h
+++ b/src/LunarSessionWorker.h
@@ -1,0 +1,53 @@
+#ifndef CELESTIAL_NAVIGATION_LUNAR_SESSION_WORKER_H
+#define CELESTIAL_NAVIGATION_LUNAR_SESSION_WORKER_H
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include <wx/string.h>
+#include <wx/thread.h>
+
+#include "LunarSessionEngine.h"
+
+namespace celestial_navigation {
+
+// Runs the bounded lunar-session solver without using the MSVC STL/PPL async
+// bridge. See EclipseVerificationWorker for the host-runtime compatibility
+// issue which requires wx-native threading here as well.
+class LunarSessionWorker {
+public:
+  typedef std::function<lunar_session::Result(
+      const std::vector<lunar_session::SessionObservation>&,
+      const lunar_session::Options&)>
+      SolveFunction;
+
+  explicit LunarSessionWorker(const SolveFunction& solve = SolveFunction());
+  ~LunarSessionWorker();
+
+  LunarSessionWorker(const LunarSessionWorker&) = delete;
+  LunarSessionWorker& operator=(const LunarSessionWorker&) = delete;
+
+  bool Start(const std::vector<lunar_session::SessionObservation>& entries,
+             const lunar_session::Options& options, wxString* error);
+  bool TryTakeResult(lunar_session::Result* result);
+  void Wait();
+
+private:
+  class WorkerThread;
+
+  void Publish(const lunar_session::Result& result);
+  static lunar_session::Result Solve(
+      const std::vector<lunar_session::SessionObservation>& entries,
+      const lunar_session::Options& options);
+
+  SolveFunction m_solve;
+  mutable wxCriticalSection m_result_lock;
+  lunar_session::Result m_result;
+  bool m_result_ready;
+  WorkerThread* m_thread;
+};
+
+}  // namespace celestial_navigation
+
+#endif

--- a/src/LunarToolsDialog.cpp
+++ b/src/LunarToolsDialog.cpp
@@ -6,6 +6,7 @@
 #include "NavigationUIUtils.h"
 #include "OcpnApiCompat.h"
 #include "Sight.h"
+#include "LunarSessionWorker.h"
 #include "UtcDateTime.h"
 #include "Utf8Translation.h"
 #include "astrolabe/astrolabe.hpp"
@@ -27,9 +28,7 @@
 
 #include <algorithm>
 #include <atomic>
-#include <chrono>
 #include <cmath>
-#include <future>
 #include <memory>
 #include <sstream>
 
@@ -785,17 +784,19 @@ void LunarToolsDialog::SolveSequence(wxCommandEvent&) {
     completedStarts.store(completed);
     totalStarts.store(total);
   };
-  std::future<lunar_session::Result> future = std::async(
-      std::launch::async,
-      [entries, options]() { return lunar_session::Solve(entries, options); });
+  celestial_navigation::LunarSessionWorker worker;
+  wxString workerError;
+  if (!worker.Start(entries, options, &workerError)) {
+    m_sequenceSummary->SetLabel(workerError);
+    return;
+  }
   wxProgressDialog progress(
       _("Lunar sequence"), CN_UTF8_("Preparing bounded multi-start solution…"),
       100, this,
       wxPD_APP_MODAL | wxPD_CAN_ABORT | wxPD_ELAPSED_TIME |
           wxPD_REMAINING_TIME | wxPD_SMOOTH | wxPD_AUTO_HIDE);
   bool userCancelled = false;
-  while (future.wait_for(std::chrono::milliseconds(75)) !=
-         std::future_status::ready) {
+  while (!worker.TryTakeResult(&m_sequenceResult)) {
     const std::size_t total = totalStarts.load();
     const std::size_t completed = completedStarts.load();
     const int percent =
@@ -812,8 +813,9 @@ void LunarToolsDialog::SolveSequence(wxCommandEvent&) {
       userCancelled = true;
       cancelRequested.store(true);
     }
+    wxMilliSleep(75);
+    wxYieldIfNeeded();
   }
-  m_sequenceResult = future.get();
   if (!userCancelled) progress.Update(100, _("Lunar sequence complete."));
   m_sequenceCandidate->Clear();
   m_sequenceResiduals->DeleteAllItems();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,11 +26,13 @@ add_subdirectory(${CMAKE_SOURCE_DIR}/opencpn-libs/tinyxml ${CMAKE_CURRENT_BINARY
 set(SRC
     atomic_xml_file_tests.cpp
     eclipse_data_files_tests.cpp
+    eclipse_verification_worker_tests.cpp
     altitude_tests.cpp
     azimuth_tests.cpp
     lunar_tests.cpp
     lunar_distance_engine_tests.cpp
     lunar_session_engine_tests.cpp
+    lunar_session_worker_tests.cpp
     sextant_calibration_engine_tests.cpp
     lunar_de440_tests.cpp
     coastal_navigation_tests.cpp
@@ -47,8 +49,10 @@ set(SRC
     ${CMAKE_SOURCE_DIR}/src/Sight.cpp
     ${CMAKE_SOURCE_DIR}/src/AtomicXmlFile.cpp
     ${CMAKE_SOURCE_DIR}/src/EclipseDataFiles.cpp
+    ${CMAKE_SOURCE_DIR}/src/EclipseVerificationWorker.cpp
     ${CMAKE_SOURCE_DIR}/src/LunarDistanceEngine.cpp
     ${CMAKE_SOURCE_DIR}/src/LunarSessionEngine.cpp
+    ${CMAKE_SOURCE_DIR}/src/LunarSessionWorker.cpp
     ${CMAKE_SOURCE_DIR}/src/SextantCalibrationEngine.cpp
     ${CMAKE_SOURCE_DIR}/src/LunarToolsDialog.cpp
     ${CMAKE_SOURCE_DIR}/src/CoastalNavigationEngine.cpp

--- a/test/eclipse_verification_worker_tests.cpp
+++ b/test/eclipse_verification_worker_tests.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include <wx/init.h>
+#include <wx/utils.h>
+
+#include "EclipseVerificationWorker.h"
+
+namespace {
+
+bool AwaitResult(
+    celestial_navigation::EclipseVerificationWorker* worker,
+    celestial_navigation::EclipseVerificationWorker::Result* result) {
+  for (int attempt = 0; attempt < 5000; ++attempt) {
+    if (worker->TryTakeResult(result)) return true;
+    wxMilliSleep(2);
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST(EclipseVerificationWorker, ReturnsBackgroundVerificationResult) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  using celestial_navigation::EclipseDataKind;
+  using celestial_navigation::EclipseVerificationWorker;
+  EclipseVerificationWorker worker(
+      [](EclipseDataKind kind, const std::string& path) {
+        EclipseVerificationWorker::Result result;
+        result.valid = kind == EclipseDataKind::De440s && path == "test.bsp";
+        result.error = result.valid ? "" : "unexpected input";
+        return result;
+      });
+
+  wxString error;
+  ASSERT_TRUE(worker.Start(EclipseDataKind::De440s, "test.bsp", &error))
+      << error;
+  EclipseVerificationWorker::Result result;
+  ASSERT_TRUE(AwaitResult(&worker, &result));
+  EXPECT_TRUE(result.valid);
+  EXPECT_TRUE(result.error.empty());
+}
+
+TEST(EclipseVerificationWorker, RejectsASecondConcurrentTask) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  using celestial_navigation::EclipseDataKind;
+  using celestial_navigation::EclipseVerificationWorker;
+  EclipseVerificationWorker worker([](EclipseDataKind, const std::string&) {
+    wxMilliSleep(30);
+    EclipseVerificationWorker::Result result;
+    result.valid = true;
+    return result;
+  });
+
+  wxString error;
+  ASSERT_TRUE(worker.Start(EclipseDataKind::De440s, "first", &error));
+  EXPECT_FALSE(worker.Start(EclipseDataKind::De440s, "second", &error));
+  EXPECT_FALSE(error.empty());
+  EclipseVerificationWorker::Result result;
+  ASSERT_TRUE(AwaitResult(&worker, &result));
+  EXPECT_TRUE(result.valid);
+}
+
+TEST(EclipseVerificationWorker, DestructionWaitsForActiveTask) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  using celestial_navigation::EclipseDataKind;
+  using celestial_navigation::EclipseVerificationWorker;
+  bool completed = false;
+  {
+    EclipseVerificationWorker worker(
+        [&completed](EclipseDataKind, const std::string&) {
+          wxMilliSleep(20);
+          completed = true;
+          EclipseVerificationWorker::Result result;
+          result.valid = true;
+          return result;
+        });
+    wxString error;
+    ASSERT_TRUE(worker.Start(EclipseDataKind::De440s, "test", &error));
+  }
+  EXPECT_TRUE(completed);
+}
+
+TEST(EclipseVerificationWorker, VerifiesTheRealDe440FileOffTheCallingThread) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  using celestial_navigation::EclipseDataKind;
+  using celestial_navigation::EclipseVerificationWorker;
+  EclipseVerificationWorker worker;
+
+  wxString error;
+  ASSERT_TRUE(
+      worker.Start(EclipseDataKind::De440s, ECLIPSE_DE440_TEST_PATH, &error))
+      << error;
+  EclipseVerificationWorker::Result result;
+  ASSERT_TRUE(AwaitResult(&worker, &result));
+  EXPECT_TRUE(result.valid) << result.error;
+}
+
+TEST(EclipseVerificationWorker, CanVerifyInstalledFilesSequentially) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  using celestial_navigation::EclipseDataKind;
+  using celestial_navigation::EclipseVerificationWorker;
+  EclipseVerificationWorker worker(
+      [](EclipseDataKind, const std::string& path) {
+        EclipseVerificationWorker::Result result;
+        result.valid = path == "first";
+        result.error = result.valid ? "" : "expected test rejection";
+        return result;
+      });
+
+  wxString error;
+  EclipseVerificationWorker::Result result;
+  ASSERT_TRUE(worker.Start(EclipseDataKind::De440s, "first", &error));
+  ASSERT_TRUE(AwaitResult(&worker, &result));
+  EXPECT_TRUE(result.valid);
+
+  ASSERT_TRUE(worker.Start(EclipseDataKind::LunarOrientation, "second",
+                           &error));
+  ASSERT_TRUE(AwaitResult(&worker, &result));
+  EXPECT_FALSE(result.valid);
+  EXPECT_EQ("expected test rejection", result.error);
+}

--- a/test/lunar_session_worker_tests.cpp
+++ b/test/lunar_session_worker_tests.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+
+#include <wx/init.h>
+#include <wx/utils.h>
+
+#include "LunarSessionWorker.h"
+
+namespace {
+
+bool AwaitResult(celestial_navigation::LunarSessionWorker* worker,
+                 lunar_session::Result* result) {
+  for (int attempt = 0; attempt < 5000; ++attempt) {
+    if (worker->TryTakeResult(result)) return true;
+    wxMilliSleep(2);
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST(LunarSessionWorker, ReturnsBackgroundSolverResult) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  celestial_navigation::LunarSessionWorker worker(
+      [](const std::vector<lunar_session::SessionObservation>& entries,
+         const lunar_session::Options&) {
+        lunar_session::Result result;
+        result.valid = entries.size() == 1;
+        result.error = result.valid ? "" : "unexpected entries";
+        return result;
+      });
+
+  std::vector<lunar_session::SessionObservation> entries(1);
+  lunar_session::Options options;
+  wxString error;
+  ASSERT_TRUE(worker.Start(entries, options, &error)) << error;
+  lunar_session::Result result;
+  ASSERT_TRUE(AwaitResult(&worker, &result));
+  EXPECT_TRUE(result.valid);
+  EXPECT_TRUE(result.error.empty());
+}
+
+TEST(LunarSessionWorker, RejectsASecondConcurrentCalculation) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  celestial_navigation::LunarSessionWorker worker(
+      [](const std::vector<lunar_session::SessionObservation>&,
+         const lunar_session::Options&) {
+        wxMilliSleep(30);
+        lunar_session::Result result;
+        result.valid = true;
+        return result;
+      });
+
+  std::vector<lunar_session::SessionObservation> entries;
+  lunar_session::Options options;
+  wxString error;
+  ASSERT_TRUE(worker.Start(entries, options, &error));
+  EXPECT_FALSE(worker.Start(entries, options, &error));
+  EXPECT_FALSE(error.empty());
+  lunar_session::Result result;
+  ASSERT_TRUE(AwaitResult(&worker, &result));
+  EXPECT_TRUE(result.valid);
+}
+
+TEST(LunarSessionWorker, DestructionWaitsForActiveCalculation) {
+  wxInitializer wx;
+  ASSERT_TRUE(wx.IsOk());
+  bool completed = false;
+  {
+    celestial_navigation::LunarSessionWorker worker(
+        [&completed](const std::vector<lunar_session::SessionObservation>&,
+                     const lunar_session::Options&) {
+          wxMilliSleep(20);
+          completed = true;
+          lunar_session::Result result;
+          result.valid = true;
+          return result;
+        });
+    std::vector<lunar_session::SessionObservation> entries;
+    lunar_session::Options options;
+    wxString error;
+    ASSERT_TRUE(worker.Start(entries, options, &error));
+  }
+  EXPECT_TRUE(completed);
+}


### PR DESCRIPTION
## Summary

- replace the MSVC STL/PPL `std::async` path used after astronomy-data downloads with a joinable wxWidgets worker
- preserve the existing verify-then-atomic-install workflow and safe cleanup of temporary downloads
- apply the same host-runtime compatibility fix to the lunar multi-reading solver, the only other `std::async` path in the plugin
- bump the plugin version to 2.8.4.1

## Why

The Windows release package runs inside OpenCPN with its bundled MSVC runtime. Rick's debugger captured the crash in `Concurrency::details::_TaskProcHandle::_RunChoreBridge` immediately after a download completed. Avoiding the PPL-backed asynchronous bridge keeps background work on the host wxWidgets threading ABI already used elsewhere in the plugin.

## Validation

- full Release build and test suite: pass
- real 31.2 MiB DE440 checksum/structure verification through the new worker: pass
- sequential startup verification and failure result: pass
- worker result, concurrent-start rejection and destruction/wait coverage: pass
- full AddressSanitizer suite: pass (leak detection disabled under ptrace)
- release tarball built and inspected; no ephemeris or temporary download data included
- no remaining `std::async`, `std::future` or PPL task path in plugin source

A final runtime check on Rick's affected 32-bit Windows/OpenCPN installation is still the decisive confirmation.